### PR TITLE
Created the destination directory for the logo before attempting to w…

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -51,6 +51,9 @@ compileSass {
 }
 
 task makeLogo(type: Exec) {
+    doFirst {
+        mkdir("build/resources/main")
+    }
     workingDir "build/resources/main"
     // Sizes from https://docs.microsoft.com/en-us/windows/desktop/uxguide/vis-icons
     commandLine "magick", \


### PR DESCRIPTION
…rite into it (this was the cause of the logo task failure on Mac).